### PR TITLE
Potential fix for code scanning alert no. 1: Implicit narrowing conversion in compound assignment

### DIFF
--- a/opt-engine/apps/nextday-delivery/src/main/java/dev/aws/proto/apps/nextday/planner/solution/SolutionConsumer.java
+++ b/opt-engine/apps/nextday-delivery/src/main/java/dev/aws/proto/apps/nextday/planner/solution/SolutionConsumer.java
@@ -129,7 +129,7 @@ public class SolutionConsumer {
             points.add(vehicle.getLocation().getCoordinate());
 
             int totalLoads = 0;
-            int totalDistance = 0;
+            long totalDistance = 0L;
             VisitOrVehicle currVisit = vehicle;
             PlanningVisit nextVisit = vehicle.getNextPlanningVisit();
             while (nextVisit != null) {


### PR DESCRIPTION
Potential fix for [https://github.com/aws-samples/delivery-routes-optimization-for-logistics/security/code-scanning/1](https://github.com/aws-samples/delivery-routes-optimization-for-logistics/security/code-scanning/1)

In general, to fix implicit narrowing in compound assignments, ensure the left-hand variable is at least as wide as the right-hand expression, or explicitly and consciously cast with bounds checks if truncation is truly intended.

Here, the right-hand side of `totalDistance += ...getDistanceInMeters();` is a `long`. The best fix without changing functionality is to widen `totalDistance` from `int` to `long`, and ensure it is used consistently as a `long` in the subsequent logging. This removes the implicit cast and prevents silent overflow while preserving behavior except in extreme overflow cases (which will now be represented correctly). Concretely, in `SolutionConsumer.logSolution`, change `int totalDistance = 0;` (line 132) to `long totalDistance = 0L;`, and update the logging call on line 147 to format a `long` correctly, e.g. using `%d` (which works for both `int` and `long` in SLF4J) with no further change needed. The rest of the method can remain unchanged since `totalDistance` is only used in arithmetic with `long` and for logging.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
